### PR TITLE
Deno... Deploy our app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+
+on:
+  push:
+    branches: [devops/deno_deploy, main]
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed for auth with Deno Deploy
+      contents: read # Needed to clone the repository
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Build Web
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
+      - run: npm ci
+      - run: npm run build
+
+      - name: Upload to Deno Deploy
+        uses: denoland/deployctl@v1
+        with:
+          project: "devs-playing-poker"
+          entrypoint: "./server/server.ts"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,4 +30,5 @@ jobs:
         uses: denoland/deployctl@v1
         with:
           project: "devs-playing-poker"
-          entrypoint: "./server/server.ts"
+          root: server
+          entrypoint: "./server.ts"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./web
     permissions:
       id-token: write # Needed for auth with Deno Deploy
       contents: read # Needed to clone the repository

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ cli/tests/.test_coverage/
 /tools/wpt/certs/index.txt*
 /tools/wpt/certs/serial*
 
-dist
+www

--- a/server/deps.ts
+++ b/server/deps.ts
@@ -1,8 +1,8 @@
-export { opine, json } from 'https://deno.land/x/opine@2.2.0/mod.ts';
-export { config } from 'https://deno.land/x/dotenv/mod.ts';
+export { opine, json } from "https://deno.land/x/opine@2.2.0/mod.ts";
+import "https://deno.land/std@v0.148.0/dotenv/load.ts";
 export {
   MongoClient,
   ObjectId,
   Collection,
   Database,
-} from 'https://deno.land/x/mongo@v0.30.1/mod.ts';
+} from "https://deno.land/x/mongo@v0.30.1/mod.ts";

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,9 +1,8 @@
-import { opine, json, config, MongoClient } from "./deps.ts";
+import { opine, json, MongoClient } from "./deps.ts";
 import { RoomSchema, UserSchema } from "./types/schemas.ts";
 import seedDB from "./utils/seedDB.ts";
 import generateRoomCode from "./utils/generateRoomCode.ts";
 import checkIfRoomExists from "./utils/checkIfRoomExists.ts";
-config({ path: "./.env" });
 
 // Types (TODO: extract)
 interface CreateRoomRequest {

--- a/server/server.ts
+++ b/server/server.ts
@@ -28,8 +28,8 @@ const rooms = db.collection<RoomSchema>("rooms");
 
 server.get(
   ["/", "/create-room", "/join", "/room/*", "/assets/*"],
-  (req, res) => {
-    const path = Deno.realPathSync(
+  async (req, res) => {
+    const path = await Deno.realPath(
       req.url.includes("/assets/") ? `./www${req.url}` : "./www/index.html"
     );
     return res.sendFile(path);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,11 +3,12 @@ import type { Component } from "solid-js";
 import Landing from "./pages/Landing";
 
 const App: Component = () => {
-  return (
-    <Routes>
-      <Route path="/" component={Landing} />
-    </Routes>
-  );
+	return (
+		<Routes>
+			<Route path="/" component={Landing} />
+			<Route path="/create-room" component={() => <p>Create Room</p>} />
+		</Routes>
+	);
 };
 
 export default App;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -21,5 +21,6 @@ export default defineConfig({
 	build: {
 		target: "esnext",
 		polyfillDynamicImport: false,
+		outDir: "../server/www",
 	},
 });


### PR DESCRIPTION
This work adds a Github action to deploy the app when pushing to `main` branch.

Notable changes:
 - `deps.ts` - Transitioned from 3-rd party dotenv package to the std dotenv/load script.
   - [More info](https://github.com/pietvanzoen/deno-dotenv#migrating-from-deno-dotenv-to-deno_stddotenv)
 - `server.ts` - Add get route for proposed FE routes and assets folder.
 - `vite.config.ts` - Update build out directory to the server folder.
 - `deploy.yml` - Using deno's deployment template, builds the FE and deploys the server folder to Deno Deploy.

Everything else is prettier updates :/

See the latest from `main` at devsplayingpoker.com (when Google Domains decides it wants to that is).