### PR TITLE
Feature/33 handle stop voting event

### DIFF
--- a/server/types/socket.ts
+++ b/server/types/socket.ts
@@ -20,6 +20,10 @@ export interface StartVotingEvent {
 	event: "StartVoting";
 }
 
+export interface StopVotingEvent {
+	event: "StopVoting";
+}
+
 export interface OptionSelectedEvent {
 	event: "OptionSelected";
 	selection: number;
@@ -30,4 +34,5 @@ export type WebSocketEvent =
 	| JoinEvent
 	| OptionSelectedEvent
 	| RoomUpdateEvent
-	| StartVotingEvent;
+	| StartVotingEvent
+	| StopVotingEvent;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -27,5 +27,6 @@ export default defineConfig({
 		target: "esnext",
 		polyfillDynamicImport: false,
 		outDir: "../server/www",
+		emptyOutDir: true,
 	},
 });


### PR DESCRIPTION
closes #33 

To test, just go into a room with at least 2 users. With the moderator user, click the "Start Voting" button and voting will start. Click the "Stop Voting" button and voting will stop. You can verify by checking the `room.state` in the DB.

Also includes small update to `vite.config.ts` that enables `emptyOutDir` option, which is required since our `outDir` is not in the root of the project.