### PR TITLE
Add metrics to results screen

### DIFF
--- a/web/src/pages/Room/Room.module.scss
+++ b/web/src/pages/Room/Room.module.scss
@@ -64,8 +64,19 @@ main.room {
 			}
 
 			td {
-				font-weight: bold;
 				text-align: center;
+				font-weight: bold;
+			}
+
+			dt {
+				font-weight: normal;
+				font-size: small;
+				text-transform: uppercase;
+			}
+
+			dd {
+				margin: auto;
+				font-size: 2rem;
 			}
 		}
 	}

--- a/web/src/pages/Room/components/Metric.tsx
+++ b/web/src/pages/Room/components/Metric.tsx
@@ -1,0 +1,17 @@
+import type { Component, JSX } from "solid-js";
+
+interface MetricProps extends JSX.TdHTMLAttributes<HTMLTableCellElement> {
+	label: string;
+	value: string | number;
+}
+
+const Metric: Component<MetricProps> = ({ label, value, ...props }) => {
+	return (
+		<td {...props}>
+			<dt>{label}</dt>
+			<dd>{value}</dd>
+		</td>
+	);
+};
+
+export default Metric;


### PR DESCRIPTION
Closes #31 

This work calculates and displays the metrics based on the voting results when the room is in the Results state.
![image](https://user-images.githubusercontent.com/92868767/183524513-98b48650-cea8-4e03-9267-1c79257ed232.png)
