### PR TITLE
Deploy to fly.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
-name: Fly Deploy
+name: Production Deployment
 
-on: 
+on:
   push:
-    branches: [main, devops/deploy_to_flyio]
+    branches: [main]
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,8 @@
 name: Fly Deploy
 
-push:
-  branches: [main, devops/deploy_to_flyio]
+on: 
+  push:
+    branches: [main, devops/deploy_to_flyio]
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,35 +1,16 @@
-name: Deploy
+name: Fly Deploy
 
-on:
-  push:
-    branches: [main]
-  pull_request:
+push:
+  branches: [main, devops/deploy_to_flyio]
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
 jobs:
   deploy:
-    name: Deploy
+    name: Deploy app
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./web
-    permissions:
-      id-token: write # Needed for auth with Deno Deploy
-      contents: read # Needed to clone the repository
-
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Build Web
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.14.2
-      - run: npm ci
-      - run: npm run build
-
-      - name: Upload to Deno Deploy
-        uses: denoland/deployctl@v1
-        with:
-          project: "devs-playing-poker"
-          root: server
-          entrypoint: "./server.ts"
+      - uses: actions/checkout@v2
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./web
+    permissions:
+      id-token: write # Needed for auth with Deno Deploy
+      contents: read # Needed to clone the repository
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Build Web
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
+      - run: npm ci
+      - run: npm run build
+
+      - name: Upload to Deno Deploy
+        uses: denoland/deployctl@v1
+        with:
+          project: "devs-playing-poker"
+          root: server
+          entrypoint: "./server.ts"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,9 +1,8 @@
 name: Deploy
 
 on:
-  push:
-    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   deploy:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Preview Deployment
 
 on:
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:current-alpine AS build
+
+WORKDIR /usr/app
+
+COPY ./web ./web
+COPY ./server ./server
+
+WORKDIR /usr/app/web
+RUN npm install && npm run build
+
+FROM denoland/deno:1.25.2 AS run
+
+EXPOSE 1337
+
+COPY --from=build /usr/app/server /usr/app
+
+WORKDIR /usr/app
+RUN deno cache deps.ts
+RUN deno cache server.ts
+
+CMD ["deno", "run", "--allow-net", "--allow-env", "--allow-read", "server.ts"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,38 @@
+# fly.toml file generated for devs-playing-poker on 2022-09-13T19:52:18-04:00
+
+app = "devs-playing-poker"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 1337
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/server/controllers/socket.controller.ts
+++ b/server/controllers/socket.controller.ts
@@ -283,7 +283,9 @@ export const handleWs = (socket: WebSocket) => {
 					break;
 				}
 				case "Ping": {
+					if (!roomCode) break;
 					const roomData = await lookupRoom(roomCode);
+					if (!roomData) break;
 					const roomUpdateEvent: RoomUpdateEvent = {
 						event: "RoomUpdate",
 						roomData: roomData,

--- a/server/types/socket.ts
+++ b/server/types/socket.ts
@@ -29,10 +29,15 @@ export interface OptionSelectedEvent {
 	selection: number;
 }
 
+export interface PingEvent {
+	event: "Ping";
+}
+
 export type WebSocketEvent =
 	| ConnectEvent
 	| JoinEvent
 	| OptionSelectedEvent
 	| RoomUpdateEvent
 	| StartVotingEvent
-	| StopVotingEvent;
+	| StopVotingEvent
+	| PingEvent;


### PR DESCRIPTION
Currently at: https://devs-playing-poker.fly.dev/

The point of trying this is to get away from Deno Deploy's edge deployments and stick to a central server. Fly.io allows us to specify what regions we deploy to. Right now the only region live is NJ. I'm interested to see if this improves the sync issues.