### PR TITLE
FE - Add ability to transfer moderator

### DIFF
--- a/web/src/pages/Room/Room.module.scss
+++ b/web/src/pages/Room/Room.module.scss
@@ -48,6 +48,18 @@ main.room {
 		margin-bottom: 1rem;
 	}
 
+	td > button {
+		background-color: transparent;
+		text-decoration: underline;
+		border: none;
+		color: inherit;
+		text-align: inherit;
+		width: fit-content;
+		margin: 0;
+		padding: 0;
+		cursor: pointer;
+	}
+
 	table {
 		border: 1px solid var(--border-gray);
 		border-radius: 4px;

--- a/web/src/pages/Room/Room.tsx
+++ b/web/src/pages/Room/Room.tsx
@@ -12,7 +12,12 @@ import {
 	Switch,
 } from "solid-js";
 import styles from "./Room.module.scss";
-import type { JoinEvent, WebSocketEvent, RoomSchema } from "@/shared-types";
+import type {
+	JoinEvent,
+	WebSocketEvent,
+	RoomSchema,
+	Voter,
+} from "@/shared-types";
 import VoterTable from "./components/VoterTable";
 import Button from "@/components/Button";
 import OptionCard from "@/components/OptionCard";
@@ -107,6 +112,18 @@ const Room: Component<{ roomCode: string }> = ({ roomCode }) => {
 		});
 	});
 
+	function handleVoterClick(voter: Voter) {
+		const confirmed = confirm(
+			`Are you sure you want to make ${voter.name} the new moderator?`,
+		);
+		if (confirmed) {
+			roomDetails()?.dispatchEvent({
+				event: "ModeratorChange",
+				newModeratorId: voter.id,
+			});
+		}
+	}
+
 	// the user object of the current user if they're a voter. null if they're the moderator
 	const currentVoter = createMemo(
 		() =>
@@ -149,7 +166,11 @@ const Room: Component<{ roomCode: string }> = ({ roomCode }) => {
 										</Button>
 									</Match>
 								</Switch>
-								<VoterTable roomState={details.state} voters={details.voters} />
+								<VoterTable
+									roomState={details.state}
+									voters={details.voters}
+									onVoterClick={handleVoterClick}
+								/>
 							</Match>
 							{/* if not the moderator, determine which UI to show based on room state */}
 							<Match when={details.state === "Results"}>

--- a/web/src/pages/Room/components/VoterTable.tsx
+++ b/web/src/pages/Room/components/VoterTable.tsx
@@ -1,10 +1,11 @@
 import { Component, For, Match, Switch } from "solid-js";
-import { RoomSchema, ConfidenceValue } from "@/shared-types";
+import { RoomSchema, ConfidenceValue, Voter } from "@/shared-types";
 import Metric from "./Metric";
 
 interface VoterTableProps {
 	voters: RoomSchema["voters"];
 	roomState: RoomSchema["state"];
+	onVoterClick?: (voter: Voter) => void;
 }
 
 const ConfidenceEmojiMap: Record<ConfidenceValue, string> = {
@@ -27,7 +28,11 @@ function formatSelection(selection: number | null): string | number {
 	return selection;
 }
 
-const VoterTable: Component<VoterTableProps> = ({ roomState, voters }) => {
+const VoterTable: Component<VoterTableProps> = ({
+	roomState,
+	voters,
+	onVoterClick,
+}) => {
 	let high = -1,
 		low = Infinity,
 		mode = -1,
@@ -76,7 +81,15 @@ const VoterTable: Component<VoterTableProps> = ({ roomState, voters }) => {
 				<For each={voters}>
 					{(voter) => (
 						<tr>
-							<td colspan="2">{voter.name}</td>
+							<td colspan="2">
+								{onVoterClick ? (
+									<button onClick={() => onVoterClick(voter)}>
+										{voter.name}
+									</button>
+								) : (
+									voter.name
+								)}
+							</td>
 							<td>
 								{roomState === "Results"
 									? formatSelection(voter.selection)


### PR DESCRIPTION
Closes #47 

This work turns the voter names into buttons if the current user is the moderator of the room. When clicked the moderator is prompted to confirm the transfer of duties. If confirmed, the moderator is transfered.

![TheTransferOfDuties](https://user-images.githubusercontent.com/92868767/190830299-5836c746-1f9b-48f8-ae2e-c6eba9ff453b.gif)
