### PR TITLE
Add ability to kick voters from a room

### DIFF
--- a/server/routes/socket.routes.ts
+++ b/server/routes/socket.routes.ts
@@ -1,8 +1,19 @@
-import { Router } from "../deps.ts";
-import { establishSocketConnection } from "../controllers/socket.controller.ts";
+import { getCookies, Router } from "../deps.ts";
+import { handleWs } from "../controllers/socket.controller.ts";
 
 const router = Router();
 
-router.get("/", establishSocketConnection);
+router.get("/", async (req, res, next) => {
+	if (req.headers.get("upgrade") === "websocket") {
+		const sock = req.upgrade();
+		const sessionId = getCookies(req.headers)["session"];
+
+		await handleWs(sock, sessionId);
+	} else {
+		return res.send("You've gotta set the magic header...");
+	}
+
+	next();
+});
 
 export default router;

--- a/server/types/socket.ts
+++ b/server/types/socket.ts
@@ -34,11 +34,35 @@ export interface OptionSelectedEvent {
 	selection: number;
 }
 
-export type WebSocketEvent =
-	| ModeratorChangeEvent
+export interface KickVoterEvent {
+	event: "KickVoter";
+	voterId: string;
+}
+
+/**
+ * Event sent to the kicked voter
+ */
+export interface KickedEvent {
+	event: "Kicked";
+}
+
+/**
+ * Events triggered from the server
+ */
+export type WebSocketTriggeredEvent =
 	| ConnectEvent
-	| JoinEvent
-	| OptionSelectedEvent
 	| RoomUpdateEvent
+	| KickedEvent;
+
+/**
+ * Events triggered by the client
+ */
+export type WebScoketMessageEvent =
+	| JoinEvent
+	| ModeratorChangeEvent
+	| OptionSelectedEvent
 	| StartVotingEvent
-	| StopVotingEvent;
+	| StopVotingEvent
+	| KickVoterEvent;
+
+export type WebSocketEvent = WebSocketTriggeredEvent | WebScoketMessageEvent;

--- a/server/utils/db.ts
+++ b/server/utils/db.ts
@@ -19,6 +19,22 @@ const connectToDb = async () => {
 	const rooms = collectionList.includes("rooms")
 		? db.collection<RoomSchema>("rooms")
 		: await db.createCollection<RoomSchema>("rooms");
+
+	const roomIndexes = await rooms.listIndexes().toArray();
+	if (roomIndexes.every((index) => index.name !== "RoomCode")) {
+		await rooms.createIndexes({
+			indexes: [
+				{
+					key: {
+						roomCode: "text",
+					},
+					name: "RoomCode",
+					unique: true,
+				},
+			],
+		});
+	}
+
 	const sessions = collectionList.includes("sessions")
 		? db.collection<SessionSchema>("sessions")
 		: await db.createCollection<SessionSchema>("sessions");

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,9 @@
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
+				"@zag-js/dialog": "^0.2.5",
+				"@zag-js/menu": "^0.3.2",
+				"@zag-js/solid": "^0.2.3",
 				"solid-app-router": "^0.4.2",
 				"solid-js": "^1.6.5"
 			},
@@ -832,6 +835,19 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.4.tgz",
+			"integrity": "sha512-FPFLbg2b06MIw1dqk2SOEMAMX3xlrreGjcui5OTxfBDtaKTmh0kioOVjT8gcfl58juawL/yF+S+gnq8aUYQx/Q=="
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.10.tgz",
+			"integrity": "sha512-ZRe5ZmtGYCd82zrjWnnMW8hN5H1otedLh0Ur6rRo6f0exbEe6IlkVvo1RO7tgiMvbF0Df8hkhdm50VcVYqwP6g==",
+			"dependencies": {
+				"@floating-ui/core": "^1.0.4"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -877,6 +893,107 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@zag-js/anatomy": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-0.1.2.tgz",
+			"integrity": "sha512-sj+KuCdPG+wAkAeyROXbN9FbVLTrDZk3N/Am1lL+TQKmZH28NRezt0Wf9arVHCJ+mDnZhW173CoxZ8B5cKT8Kw=="
+		},
+		"node_modules/@zag-js/aria-hidden": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-0.2.0.tgz",
+			"integrity": "sha512-NjCybo9zICpJh/eVnckzNFqqoC5tEyXpogjudqWAxLPVewp+plmOBfqtrYwWMbRJ87mtxkCUUpWKTP3en4WtmQ=="
+		},
+		"node_modules/@zag-js/core": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@zag-js/core/-/core-0.2.3.tgz",
+			"integrity": "sha512-+YjI1cPnvd3DEuWEO/MWg88OrV6Wh5uO1c0Azb6+9QOrlKfBTEGPJUy5KWd2greyTw9oXyUJX3CsEw8YbRVTIw==",
+			"dependencies": {
+				"@zag-js/store": "0.2.1",
+				"klona": "2.0.5"
+			}
+		},
+		"node_modules/@zag-js/dialog": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-0.2.5.tgz",
+			"integrity": "sha512-bL3k5Hx68n8ZaiwaSHMciL/lrkdnwY8oxK/3pBAojbiuiUVg0XtlZxRNKZhkbHtHNBp5YVLQI2tYK8vijVU6hg==",
+			"dependencies": {
+				"@zag-js/anatomy": "0.1.2",
+				"@zag-js/aria-hidden": "0.2.0",
+				"@zag-js/core": "0.2.3",
+				"@zag-js/dismissable": "0.2.0",
+				"@zag-js/remove-scroll": "0.2.0",
+				"@zag-js/types": "0.3.1",
+				"focus-trap": "7.2.0"
+			}
+		},
+		"node_modules/@zag-js/dismissable": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-0.2.0.tgz",
+			"integrity": "sha512-AP5H9szbSg4T5ntXVB86AEGLwO47Cr/LoJrydDiy2Zlk332fZ54wt8oKAI+aTkgGDF9xKp6GHnwS7JWKxGPfmQ==",
+			"dependencies": {
+				"@zag-js/interact-outside": "0.2.0"
+			}
+		},
+		"node_modules/@zag-js/interact-outside": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-0.2.0.tgz",
+			"integrity": "sha512-vj+roRkCI5NogZApuporXoWMI5uq57zWzFGsQUL2Yl91Oq7l448IvWzmmoSi+Tsgd4aGO7hwbJCvp3oqjCa5JA=="
+		},
+		"node_modules/@zag-js/menu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-0.3.2.tgz",
+			"integrity": "sha512-6OTpsSM7Ad5ui8O8wG5tMXWpf/Q5dqpgeDI/Doig6aEwLpEu7QYV5AdiS+Sio10sK5IkVMVpBV35IaQAn0Mw3Q==",
+			"dependencies": {
+				"@zag-js/anatomy": "0.1.2",
+				"@zag-js/core": "0.2.3",
+				"@zag-js/dismissable": "0.2.0",
+				"@zag-js/popper": "0.2.1",
+				"@zag-js/types": "0.3.1"
+			}
+		},
+		"node_modules/@zag-js/popper": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-0.2.1.tgz",
+			"integrity": "sha512-u9LH5/XGzhmdJxJuZe1P5pMcQVNuCrpc2r2L9jCev55xAIgegpIVjbUgebDvpYURxRrSNovQU3fXRnQPiLAw1A==",
+			"dependencies": {
+				"@floating-ui/dom": "1.0.10"
+			}
+		},
+		"node_modules/@zag-js/remove-scroll": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-0.2.0.tgz",
+			"integrity": "sha512-mxtPQnPABgAka6zVSvvauS00dgfO6+2n2c8sftdnpCnpTRq6mdCPxj4/NE169Wk5ldzxBbqmnjgYWjOlWV8lpw=="
+		},
+		"node_modules/@zag-js/solid": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@zag-js/solid/-/solid-0.2.3.tgz",
+			"integrity": "sha512-3LNcYoLa3v0ayGr0Pgt49OmYrm7uTyl/dO6zNKiITN0XMYGGKWc/dAGunGlDpj7lW9i8AlYH760muQPnLTkl0g==",
+			"dependencies": {
+				"@zag-js/core": "0.2.3",
+				"@zag-js/store": "0.2.1",
+				"@zag-js/types": "0.3.1",
+				"hyphenate-style-name": "1.0.4"
+			},
+			"peerDependencies": {
+				"solid-js": ">=1.1.3"
+			}
+		},
+		"node_modules/@zag-js/store": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@zag-js/store/-/store-0.2.1.tgz",
+			"integrity": "sha512-QYmAyh9hXRSmqKirD/nyTohSOI86fenSdtF177W88Jyv0SfaGSv4Z+o+kU6g62c+XIQVEP/W9LL3ZH075lQI9A==",
+			"dependencies": {
+				"proxy-compare": "2.3.0"
+			}
+		},
+		"node_modules/@zag-js/types": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@zag-js/types/-/types-0.3.1.tgz",
+			"integrity": "sha512-mSGkt+mqmvE+E6RAR1py74Pbzb5q2HjhijkpsUojHsDa+DIX9KJ2XTKGt9Dv3qxqwY81/pQdBQFNLDNKMAeYdQ==",
+			"dependencies": {
+				"csstype": "3.1.1"
 			}
 		},
 		"node_modules/ansi-styles": {
@@ -1168,6 +1285,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/focus-trap": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.2.0.tgz",
+			"integrity": "sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==",
+			"dependencies": {
+				"tabbable": "^6.0.1"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1244,6 +1369,11 @@
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
 			"integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
 			"dev": true
+		},
+		"node_modules/hyphenate-style-name": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+			"integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
 		},
 		"node_modules/immutable": {
 			"version": "4.1.0",
@@ -1347,6 +1477,14 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/klona": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+			"integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/merge-anything": {
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.4.tgz",
@@ -1442,6 +1580,11 @@
 			"engines": {
 				"node": "^10 || ^12 || >=14"
 			}
+		},
+		"node_modules/proxy-compare": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
+			"integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
@@ -1582,6 +1725,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/tabbable": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.1.tgz",
+			"integrity": "sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA=="
 		},
 		"node_modules/to-fast-properties": {
 			"version": "2.0.0",
@@ -2219,6 +2367,19 @@
 			"dev": true,
 			"optional": true
 		},
+		"@floating-ui/core": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.4.tgz",
+			"integrity": "sha512-FPFLbg2b06MIw1dqk2SOEMAMX3xlrreGjcui5OTxfBDtaKTmh0kioOVjT8gcfl58juawL/yF+S+gnq8aUYQx/Q=="
+		},
+		"@floating-ui/dom": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.10.tgz",
+			"integrity": "sha512-ZRe5ZmtGYCd82zrjWnnMW8hN5H1otedLh0Ur6rRo6f0exbEe6IlkVvo1RO7tgiMvbF0Df8hkhdm50VcVYqwP6g==",
+			"requires": {
+				"@floating-ui/core": "^1.0.4"
+			}
+		},
 		"@jridgewell/gen-mapping": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -2255,6 +2416,104 @@
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"@zag-js/anatomy": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-0.1.2.tgz",
+			"integrity": "sha512-sj+KuCdPG+wAkAeyROXbN9FbVLTrDZk3N/Am1lL+TQKmZH28NRezt0Wf9arVHCJ+mDnZhW173CoxZ8B5cKT8Kw=="
+		},
+		"@zag-js/aria-hidden": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-0.2.0.tgz",
+			"integrity": "sha512-NjCybo9zICpJh/eVnckzNFqqoC5tEyXpogjudqWAxLPVewp+plmOBfqtrYwWMbRJ87mtxkCUUpWKTP3en4WtmQ=="
+		},
+		"@zag-js/core": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@zag-js/core/-/core-0.2.3.tgz",
+			"integrity": "sha512-+YjI1cPnvd3DEuWEO/MWg88OrV6Wh5uO1c0Azb6+9QOrlKfBTEGPJUy5KWd2greyTw9oXyUJX3CsEw8YbRVTIw==",
+			"requires": {
+				"@zag-js/store": "0.2.1",
+				"klona": "2.0.5"
+			}
+		},
+		"@zag-js/dialog": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-0.2.5.tgz",
+			"integrity": "sha512-bL3k5Hx68n8ZaiwaSHMciL/lrkdnwY8oxK/3pBAojbiuiUVg0XtlZxRNKZhkbHtHNBp5YVLQI2tYK8vijVU6hg==",
+			"requires": {
+				"@zag-js/anatomy": "0.1.2",
+				"@zag-js/aria-hidden": "0.2.0",
+				"@zag-js/core": "0.2.3",
+				"@zag-js/dismissable": "0.2.0",
+				"@zag-js/remove-scroll": "0.2.0",
+				"@zag-js/types": "0.3.1",
+				"focus-trap": "7.2.0"
+			}
+		},
+		"@zag-js/dismissable": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-0.2.0.tgz",
+			"integrity": "sha512-AP5H9szbSg4T5ntXVB86AEGLwO47Cr/LoJrydDiy2Zlk332fZ54wt8oKAI+aTkgGDF9xKp6GHnwS7JWKxGPfmQ==",
+			"requires": {
+				"@zag-js/interact-outside": "0.2.0"
+			}
+		},
+		"@zag-js/interact-outside": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-0.2.0.tgz",
+			"integrity": "sha512-vj+roRkCI5NogZApuporXoWMI5uq57zWzFGsQUL2Yl91Oq7l448IvWzmmoSi+Tsgd4aGO7hwbJCvp3oqjCa5JA=="
+		},
+		"@zag-js/menu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-0.3.2.tgz",
+			"integrity": "sha512-6OTpsSM7Ad5ui8O8wG5tMXWpf/Q5dqpgeDI/Doig6aEwLpEu7QYV5AdiS+Sio10sK5IkVMVpBV35IaQAn0Mw3Q==",
+			"requires": {
+				"@zag-js/anatomy": "0.1.2",
+				"@zag-js/core": "0.2.3",
+				"@zag-js/dismissable": "0.2.0",
+				"@zag-js/popper": "0.2.1",
+				"@zag-js/types": "0.3.1"
+			}
+		},
+		"@zag-js/popper": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-0.2.1.tgz",
+			"integrity": "sha512-u9LH5/XGzhmdJxJuZe1P5pMcQVNuCrpc2r2L9jCev55xAIgegpIVjbUgebDvpYURxRrSNovQU3fXRnQPiLAw1A==",
+			"requires": {
+				"@floating-ui/dom": "1.0.10"
+			}
+		},
+		"@zag-js/remove-scroll": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-0.2.0.tgz",
+			"integrity": "sha512-mxtPQnPABgAka6zVSvvauS00dgfO6+2n2c8sftdnpCnpTRq6mdCPxj4/NE169Wk5ldzxBbqmnjgYWjOlWV8lpw=="
+		},
+		"@zag-js/solid": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@zag-js/solid/-/solid-0.2.3.tgz",
+			"integrity": "sha512-3LNcYoLa3v0ayGr0Pgt49OmYrm7uTyl/dO6zNKiITN0XMYGGKWc/dAGunGlDpj7lW9i8AlYH760muQPnLTkl0g==",
+			"requires": {
+				"@zag-js/core": "0.2.3",
+				"@zag-js/store": "0.2.1",
+				"@zag-js/types": "0.3.1",
+				"hyphenate-style-name": "1.0.4"
+			}
+		},
+		"@zag-js/store": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@zag-js/store/-/store-0.2.1.tgz",
+			"integrity": "sha512-QYmAyh9hXRSmqKirD/nyTohSOI86fenSdtF177W88Jyv0SfaGSv4Z+o+kU6g62c+XIQVEP/W9LL3ZH075lQI9A==",
+			"requires": {
+				"proxy-compare": "2.3.0"
+			}
+		},
+		"@zag-js/types": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@zag-js/types/-/types-0.3.1.tgz",
+			"integrity": "sha512-mSGkt+mqmvE+E6RAR1py74Pbzb5q2HjhijkpsUojHsDa+DIX9KJ2XTKGt9Dv3qxqwY81/pQdBQFNLDNKMAeYdQ==",
+			"requires": {
+				"csstype": "3.1.1"
 			}
 		},
 		"ansi-styles": {
@@ -2463,6 +2722,14 @@
 				"to-regex-range": "^5.0.1"
 			}
 		},
+		"focus-trap": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.2.0.tgz",
+			"integrity": "sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==",
+			"requires": {
+				"tabbable": "^6.0.1"
+			}
+		},
 		"fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -2517,6 +2784,11 @@
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
 			"integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
 			"dev": true
+		},
+		"hyphenate-style-name": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+			"integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
 		},
 		"immutable": {
 			"version": "4.1.0",
@@ -2587,6 +2859,11 @@
 			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
 			"dev": true
 		},
+		"klona": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+			"integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
+		},
 		"merge-anything": {
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-5.1.4.tgz",
@@ -2648,6 +2925,11 @@
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
+		},
+		"proxy-compare": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
+			"integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ=="
 		},
 		"readdirp": {
 			"version": "3.6.0",
@@ -2746,6 +3028,11 @@
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
 			"dev": true
+		},
+		"tabbable": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.1.tgz",
+			"integrity": "sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA=="
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,9 @@
 		"vite-plugin-solid": "^2.5.0"
 	},
 	"dependencies": {
+		"@zag-js/dialog": "^0.2.5",
+		"@zag-js/menu": "^0.3.2",
+		"@zag-js/solid": "^0.2.3",
 		"solid-app-router": "^0.4.2",
 		"solid-js": "^1.6.5"
 	}

--- a/web/src/components/Button/Button.module.scss
+++ b/web/src/components/Button/Button.module.scss
@@ -24,6 +24,44 @@
 			cursor: not-allowed;
 		}
 	}
+
+	&.outline {
+		background-color: transparent;
+		border: 2px solid var(--primary-orange);
+		color: var(--primary-text-color);
+
+		&:hover:not(:disabled) {
+			background-color: var(--alpha-orange);
+			cursor: pointer;
+		}
+		&:active:not(:disabled) {
+			border-color: var(--border-gray);
+			color: var(--border-gray);
+		}
+		&:disabled {
+			border-color: var(--border-gray);
+			color: var(--border-gray);
+			cursor: not-allowed;
+		}
+	}
+
+	&.ghost {
+		background-color: transparent;
+
+		&:hover:not(:disabled) {
+			background-color: var(--alpha-orange);
+			cursor: pointer;
+		}
+		&:active:not(:disabled) {
+			border-color: var(--border-gray);
+			color: var(--border-gray);
+		}
+		&:disabled {
+			border-color: var(--border-gray);
+			color: var(--border-gray);
+			cursor: not-allowed;
+		}
+	}
 }
 
 button.button {

--- a/web/src/components/Button/Button.tsx
+++ b/web/src/components/Button/Button.tsx
@@ -26,7 +26,7 @@ export const ButtonLink: Component<ButtonLinkProps> = ({
 };
 
 interface ButtonProps extends JSX.ButtonHTMLAttributes<HTMLButtonElement> {
-	variant?: "solid" | "outline";
+	variant?: "solid" | "outline" | "ghost";
 	loading?: boolean;
 	disabled?: boolean;
 }

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -7,6 +7,8 @@
 	--error-text-color: red;
 	--main-background: #fafafa;
 	--elevated-background: #ffffff;
+	--shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+		0 10px 10px -5px rgba(0, 0, 0, 0.04);
 }
 
 body {
@@ -68,4 +70,15 @@ hr {
 	border-style: solid;
 	border-bottom-width: 1px;
 	overflow: visible;
+}
+
+@keyframes flipIn {
+	from {
+		scale: 0.9;
+		opacity: 0;
+	}
+	to {
+		scale: 1;
+		opacity: 1;
+	}
 }

--- a/web/src/pages/Room/Room.module.scss
+++ b/web/src/pages/Room/Room.module.scss
@@ -2,7 +2,6 @@ button.roomCodeBtn {
 	display: flex;
 	align-items: center;
 	position: relative;
-	z-index: 1;
 	cursor: copy;
 
 	margin: auto;
@@ -34,8 +33,8 @@ button.roomCodeBtn {
 				text-decoration: underline;
 			}
 
-			&::before {
-				content: "🏠 ";
+			span[aria-hidden] {
+				margin-right: 0.25rem;
 			}
 		}
 	}

--- a/web/src/pages/Room/components/VoterTable/VoterTable.module.scss
+++ b/web/src/pages/Room/components/VoterTable/VoterTable.module.scss
@@ -30,7 +30,7 @@ table.voterTable {
 	.voterName {
 		text-overflow: ellipsis;
 		overflow: hidden;
-		width: 100%;
+		max-width: 100%;
 	}
 
 	td > button {

--- a/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/OptionConfirmationDialog.module.scss
+++ b/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/OptionConfirmationDialog.module.scss
@@ -17,6 +17,7 @@
 	position: absolute;
 	inset: 0;
 	width: 25rem;
+	max-width: 90%;
 	height: fit-content;
 	margin: auto;
 

--- a/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/OptionConfirmationDialog.module.scss
+++ b/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/OptionConfirmationDialog.module.scss
@@ -1,3 +1,5 @@
+@use "../../../../../../index.scss";
+
 .optionConfirmationBackdrop {
 	background-color: rgba(0, 0, 0, 0.25);
 	position: absolute;
@@ -5,11 +7,12 @@
 }
 
 .optionConfirmationContainer {
+	animation: flipIn 200ms cubic-bezier(0.165, 0.84, 0.44, 1);
+
 	background-color: var(--elevated-background);
 	border-radius: 0.5rem;
 	padding: 1rem 1.25rem;
-	box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
-		0 10px 10px -5px rgba(0, 0, 0, 0.04);
+	box-shadow: var(--shadow-xl);
 
 	position: absolute;
 	inset: 0;

--- a/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/OptionConfirmationDialog.module.scss
+++ b/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/OptionConfirmationDialog.module.scss
@@ -1,0 +1,48 @@
+.optionConfirmationBackdrop {
+	background-color: rgba(0, 0, 0, 0.25);
+	position: absolute;
+	inset: 0;
+}
+
+.optionConfirmationContainer {
+	background-color: var(--elevated-background);
+	border-radius: 0.5rem;
+	padding: 1rem 1.25rem;
+	box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+		0 10px 10px -5px rgba(0, 0, 0, 0.04);
+
+	position: absolute;
+	inset: 0;
+	width: 25rem;
+	height: fit-content;
+	margin: auto;
+
+	[data-part="close-trigger"] {
+		position: absolute;
+		color: var(--primary-text-color);
+		top: 0.25rem;
+		right: 0.25rem;
+		width: 2rem;
+		height: 2rem;
+		padding: 0;
+	}
+
+	[data-part="title"] {
+		font-size: 1.25rem;
+	}
+
+	[data-part="description"] {
+		padding-top: 1.25rem;
+		padding-bottom: 2rem;
+	}
+
+	div[role="group"] {
+		display: flex;
+		gap: 0.5rem;
+		justify-content: flex-end;
+
+		& > button {
+			padding: 0.3rem 0.5rem;
+		}
+	}
+}

--- a/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/OptionConfirmationDialog.tsx
+++ b/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/OptionConfirmationDialog.tsx
@@ -1,0 +1,91 @@
+import * as dialog from "@zag-js/dialog";
+import { Portal } from "solid-js/web";
+import { useMachine, normalizeProps } from "@zag-js/solid";
+import { Component, createMemo, createUniqueId } from "solid-js";
+import type { VoterClickAction } from "../VoterOptionsMenu";
+import type { Voter } from "@/shared-types";
+import styles from "./OptionConfirmationDialog.module.scss";
+import Button from "@/components/Button";
+
+interface OptionConfirmationDialogProps {
+	action: VoterClickAction;
+	voter: Voter;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+const OptionConfirmationDialog: Component<OptionConfirmationDialogProps> = ({
+	action,
+	voter,
+	onCancel,
+	onConfirm,
+}) => {
+	const [state, send] = useMachine(
+		dialog.machine({
+			id: createUniqueId(),
+			role: "alertdialog",
+			onClose: onCancel,
+			defaultOpen: true,
+			// needed to avoid body.style.paddingRight content shift
+			preventScroll: false,
+		}),
+	);
+
+	const api = createMemo(() => dialog.connect(state, send, normalizeProps));
+
+	const title = (() => {
+		switch (action) {
+			case "kickVoter":
+				return "Kick Voter";
+			case "makeModerator":
+				return "Make Moderator";
+			default:
+				return null;
+		}
+	})();
+
+	const description = () => {
+		switch (action) {
+			case "kickVoter":
+				return (
+					<span>
+						Are you sure you want to remove <b>{voter.name}</b> from the room?
+					</span>
+				);
+			case "makeModerator":
+				return (
+					<span>
+						Are you sure you want to make <b>{voter.name}</b> the new moderator?
+						This will turn you into a voter.
+					</span>
+				);
+			default:
+				return null;
+		}
+	};
+
+	return (
+		<Portal>
+			<div class={styles.optionConfirmationBackdrop} {...api().backdropProps} />
+			<div class={styles.optionConfirmationContainer} {...api().containerProps}>
+				<div {...api().contentProps}>
+					<h2 {...api().titleProps}>{title}</h2>
+					<p {...api().descriptionProps}>{description}</p>
+					<Button variant="ghost" {...api().closeTriggerProps}>
+						&#10005;
+					</Button>
+					<div role="group" onClick={() => api().close()}>
+						<Button variant="solid" onClick={() => onConfirm()}>
+							Confirm
+						</Button>
+						<Button variant="outline" onClick={() => onCancel()}>
+							Cancel
+						</Button>
+					</div>
+				</div>
+			</div>
+		</Portal>
+	);
+};
+
+export default OptionConfirmationDialog;

--- a/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/index.ts
+++ b/web/src/pages/Room/components/VoterTable/components/OptionConfirmationDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./OptionConfirmationDialog";

--- a/web/src/pages/Room/components/VoterTable/components/VoterOptionsMenu/VoterOptionsMenu.module.scss
+++ b/web/src/pages/Room/components/VoterTable/components/VoterOptionsMenu/VoterOptionsMenu.module.scss
@@ -1,0 +1,21 @@
+.voterActionMenu {
+	background-color: var(--elevated-background);
+	border-radius: 0.5rem;
+	overflow: hidden;
+	box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+		0 10px 10px -5px rgba(0, 0, 0, 0.04);
+
+	.itemIcon {
+		margin-right: 0.25rem;
+	}
+
+	[data-part="item"] {
+		list-style-type: none;
+		padding: 0.5rem 0.75rem;
+		cursor: pointer;
+
+		&[data-focus] {
+			background-color: var(--border-gray);
+		}
+	}
+}

--- a/web/src/pages/Room/components/VoterTable/components/VoterOptionsMenu/VoterOptionsMenu.module.scss
+++ b/web/src/pages/Room/components/VoterTable/components/VoterOptionsMenu/VoterOptionsMenu.module.scss
@@ -2,8 +2,7 @@
 	background-color: var(--elevated-background);
 	border-radius: 0.5rem;
 	overflow: hidden;
-	box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
-		0 10px 10px -5px rgba(0, 0, 0, 0.04);
+	box-shadow: var(--shadow-xl);
 
 	.itemIcon {
 		margin-right: 0.25rem;
@@ -15,7 +14,7 @@
 		cursor: pointer;
 
 		&[data-focus] {
-			background-color: var(--border-gray);
+			background-color: var(--alpha-orange);
 		}
 	}
 }

--- a/web/src/pages/Room/components/VoterTable/components/VoterOptionsMenu/VoterOptionsMenu.tsx
+++ b/web/src/pages/Room/components/VoterTable/components/VoterOptionsMenu/VoterOptionsMenu.tsx
@@ -1,0 +1,59 @@
+import * as menu from "@zag-js/menu";
+import { normalizeProps, useMachine } from "@zag-js/solid";
+import { Component, createMemo, createUniqueId } from "solid-js";
+import type { Voter } from "@/shared-types";
+import styles from "./VoterOptionsMenu.module.scss";
+import { Portal } from "solid-js/web";
+
+export type VoterClickAction = "makeModerator" | "kickVoter";
+
+interface VoterOptionsMenuProps {
+	voter: Voter;
+	onVoterClick: (action: VoterClickAction, voter: Voter) => void;
+}
+
+const VoterOptionsMenu: Component<VoterOptionsMenuProps> = ({
+	voter,
+	onVoterClick,
+}) => {
+	const [state, send] = useMachine(
+		menu.machine({
+			id: createUniqueId(),
+			onSelect(value) {
+				onVoterClick(value as VoterClickAction, voter);
+			},
+			closeOnSelect: true,
+			positioning: { placement: "right-start" },
+		}),
+	);
+
+	const api = createMemo(() => menu.connect(state, send, normalizeProps));
+
+	return (
+		<>
+			<button class={styles.voterName} {...api().triggerProps}>
+				{voter.name}
+			</button>
+			<Portal>
+				<div class={styles.voterActionMenu} {...api().positionerProps}>
+					<ul {...api().contentProps}>
+						<li {...api().getItemProps({ id: "makeModerator" })}>
+							<span class={styles.itemIcon} aria-hidden>
+								👑
+							</span>
+							Make moderator
+						</li>
+						<li {...api().getItemProps({ id: "kickVoter" })}>
+							<span class={styles.itemIcon} aria-hidden>
+								🥾
+							</span>
+							Kick voter
+						</li>
+					</ul>
+				</div>
+			</Portal>
+		</>
+	);
+};
+
+export default VoterOptionsMenu;

--- a/web/src/pages/Room/components/VoterTable/components/VoterOptionsMenu/index.ts
+++ b/web/src/pages/Room/components/VoterTable/components/VoterOptionsMenu/index.ts
@@ -1,0 +1,1 @@
+export { default, type VoterClickAction } from "./VoterOptionsMenu";

--- a/web/src/pages/Room/components/VoterTable/index.ts
+++ b/web/src/pages/Room/components/VoterTable/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./VoterTable";
+export type { VoterClickAction } from "./components/VoterOptionsMenu";

--- a/web/src/pages/Room/views/moderator/ModeratorView.tsx
+++ b/web/src/pages/Room/views/moderator/ModeratorView.tsx
@@ -1,13 +1,20 @@
 import { Component, Match, Switch } from "solid-js";
-import type { RoomSchema, Voter, WebSocketEvent } from "@/shared-types";
+import type {
+	KickVoterEvent,
+	ModeratorChangeEvent,
+	RoomSchema,
+	Voter,
+	WebScoketMessageEvent,
+} from "@/shared-types";
 import Button from "@/components/Button";
 import VoterTable from "../../components/VoterTable";
 import styles from "./ModeratorView.module.scss";
+import type { VoterClickAction } from "../../components/VoterTable";
 
 interface ModeratorViewProps {
 	state: RoomSchema["state"];
 	voters: RoomSchema["voters"];
-	dispatchEvent: (event: WebSocketEvent) => void;
+	dispatchEvent: (event: WebScoketMessageEvent) => void;
 }
 
 const ModeratorView: Component<ModeratorViewProps> = ({
@@ -15,15 +22,24 @@ const ModeratorView: Component<ModeratorViewProps> = ({
 	voters,
 	dispatchEvent,
 }) => {
-	function handleVoterClick(voter: Voter) {
-		const confirmed = confirm(
-			`Are you sure you want to make ${voter.name} the new moderator?`,
-		);
-		if (confirmed) {
-			dispatchEvent({
-				event: "ModeratorChange",
-				newModeratorId: voter.id,
-			});
+	function handleVoterAction(action: VoterClickAction, voter: Voter) {
+		const event = (() => {
+			switch (action) {
+				case "kickVoter":
+					return {
+						event: "KickVoter",
+						voterId: voter.id,
+					} as KickVoterEvent;
+				case "makeModerator":
+					return {
+						event: "ModeratorChange",
+						newModeratorId: voter.id,
+					} as ModeratorChangeEvent;
+			}
+		})();
+
+		if (event) {
+			dispatchEvent(event);
 		}
 	}
 
@@ -53,7 +69,7 @@ const ModeratorView: Component<ModeratorViewProps> = ({
 			<VoterTable
 				roomState={state}
 				voters={voters}
-				onVoterClick={handleVoterClick}
+				onVoterAction={handleVoterAction}
 			/>
 		</>
 	);

--- a/web/src/pages/Room/views/voter/VoterView.tsx
+++ b/web/src/pages/Room/views/voter/VoterView.tsx
@@ -1,12 +1,12 @@
 import { Component, For, Match, Switch } from "solid-js";
-import type { RoomSchema, WebSocketEvent } from "@/shared-types";
+import type { RoomSchema, WebScoketMessageEvent } from "@/shared-types";
 import OptionCard from "@/components/OptionCard";
 import VoterTable from "../../components/VoterTable";
 import styles from "./VoterView.module.scss";
 
 interface VoterViewProps {
 	roomDetails: RoomSchema;
-	dispatchEvent: (event: WebSocketEvent) => void;
+	dispatchEvent: (event: WebScoketMessageEvent) => void;
 	currentUserId: string;
 }
 


### PR DESCRIPTION
Closes #49
Closes #50

This work adds the ability for moderators to kick voters from a room + some other enhancements described below.

## Changes
### Server
 - `socket.controller.ts` - Added Kick event. Added `eventHandlerMap` which abstracts how event handlers are tied to event names and allows support for middleware functions such as `validateModerator`. Each function will run in order and can stop the execution of the other functions by returning an object with a message that explains why the execution is paused.
 - `socket.routes.ts` - Moved the `establishSocketConnection` function into the routes file just to help separate the main socket action logic from the setup.
 - `types/socket.ts` - Add kick event types. Separate "Triggered" websocket events from "Message" events. Triggered events are created by the server whereas Message events are triggered by the web client. This allows for more narrow type scopes when handling events.
 - `db.ts` - Added an index on the rooms collection for roomCode since that lookup happens on _every_ event.
 
### Web
 - `Button.tsx` - Added new "ghost" variant.
 - `Room.tsx` - When a voter is kicked the server will trigger a "Kicked" event. Right now this will just redirect the user back to the homepage. More work will need to be done to prevent the voter from re-joining the room after they've been kicked, but that's out of scope for this work.
 - `VoterOptionsMenu.tsx` - Uses [zag's menu](https://zagjs.com/components/solid/menu) component to show "Make Moderator" and "Kick Voter" options when a moderator clicks on a voter in the table. Making a selection now shows the `OptionConfirmationDialog.tsx`.
 - `OptionConfirmationDialog.tsx` - Uses [zag's dialog](https://zagjs.com/components/solid/dialog) component to show the confirmation screen based on the selected action.