### PR TITLE
Add end-to-end validation

### DIFF
--- a/server/deps.ts
+++ b/server/deps.ts
@@ -18,3 +18,4 @@ export {
 	setCookie,
 	deleteCookie,
 } from "https://deno.land/std@0.168.0/http/cookie.ts";
+export { z as zod } from "https://deno.land/x/zod@v3.16.1/mod.ts";

--- a/server/middlewares/validators.ts
+++ b/server/middlewares/validators.ts
@@ -1,4 +1,4 @@
-import { NextFunction, OpineRequest, OpineResponse } from "../deps.ts";
+import { NextFunction, OpineRequest, OpineResponse, zod } from "../deps.ts";
 
 export function validateRoomCode(
 	req: OpineRequest,
@@ -15,24 +15,27 @@ export function validateRoomCode(
 	next();
 }
 
+const newRoomSchema = zod.object({
+	options: zod
+		.number()
+		.array()
+		.min(2, "Need at least 2 options.")
+		.max(15, "No more than 15 options is allowed."),
+});
+
 export function validateNewRoom(
 	req: OpineRequest,
 	res: OpineResponse,
 	next: NextFunction,
 ) {
-	const body = req.body;
+	const result = newRoomSchema.safeParse(req.body);
 
-	if (
-		"options" in body &&
-		body.options instanceof Array &&
-		body.options.length > 1
-	) {
-		return next();
+	if (!result.success) {
+		return res.setStatus(400).json({
+			success: false,
+			message: result.error.flatten().fieldErrors.options?.[0],
+		});
 	}
 
-	return res.setStatus(400).json({
-		success: false,
-		message:
-			"'options' is required and must be an array with more than option.",
-	});
+	next();
 }

--- a/server/middlewares/validators.ts
+++ b/server/middlewares/validators.ts
@@ -20,7 +20,8 @@ const newRoomSchema = zod.object({
 		.number()
 		.array()
 		.min(2, "Need at least 2 options.")
-		.max(15, "No more than 15 options is allowed."),
+		// 15 from pattern + 1 no-vote option
+		.max(15 + 1, "No more than 16 options is allowed."),
 });
 
 export function validateNewRoom(

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,8 @@
 				"@zag-js/menu": "^0.3.2",
 				"@zag-js/solid": "^0.2.3",
 				"solid-app-router": "^0.4.2",
-				"solid-js": "^1.6.5"
+				"solid-js": "^1.6.5",
+				"zod": "^3.20.2"
 			},
 			"devDependencies": {
 				"sass": "^1.57.0",
@@ -1871,6 +1872,14 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/zod": {
+			"version": "3.20.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+			"integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
 		}
 	},
 	"dependencies": {
@@ -3098,6 +3107,11 @@
 			"integrity": "sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==",
 			"dev": true,
 			"requires": {}
+		},
+		"zod": {
+			"version": "3.20.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+			"integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ=="
 		}
 	}
 }

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
 		"@zag-js/menu": "^0.3.2",
 		"@zag-js/solid": "^0.2.3",
 		"solid-app-router": "^0.4.2",
-		"solid-js": "^1.6.5"
+		"solid-js": "^1.6.5",
+		"zod": "^3.20.2"
 	}
 }

--- a/web/src/pages/CreateRoom/CreateRoom.module.scss
+++ b/web/src/pages/CreateRoom/CreateRoom.module.scss
@@ -9,7 +9,7 @@ form.createRoomForm {
 	gap: 2rem;
 	padding: 3rem 0.5rem;
 
-	& > div {
+	& > div, & > dl {
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;

--- a/web/src/pages/CreateRoom/CreateRoom.tsx
+++ b/web/src/pages/CreateRoom/CreateRoom.tsx
@@ -8,7 +8,11 @@ import zod from "zod";
 
 const createRoomSchema = zod.object({
 	voterOptions: zod.enum(["fibonacci", "linear"]),
-	numberOfOptions: zod.number().min(2).max(15),
+	// 15 from slider + 1 no-vote option
+	numberOfOptions: zod
+		.number()
+		.min(2)
+		.max(15 + 1),
 	noVote: zod.boolean(),
 });
 
@@ -184,6 +188,7 @@ const CreateRoom: Component = () => {
 							<span class={styles.required}>*</span>
 						</label>
 						<select
+							id="voterOptions"
 							name="voterOptions"
 							required
 							value={defaultFormValues?.voterOptions ?? ""}

--- a/web/src/pages/CreateRoom/CreateRoom.tsx
+++ b/web/src/pages/CreateRoom/CreateRoom.tsx
@@ -109,6 +109,7 @@ const CreateRoom: Component = () => {
 	const handleChange = (form: EventTarget & HTMLFormElement) => {
 		const { voterOptions, noVote, numberOfOptions } = getFormValues(form);
 		let fieldOptions: Array<number> = [];
+		setError(null);
 
 		if (voterOptions === "") {
 			setList("");

--- a/web/src/pages/CreateRoom/CreateRoom.tsx
+++ b/web/src/pages/CreateRoom/CreateRoom.tsx
@@ -4,17 +4,33 @@ import post from "@/utils/post";
 import Button from "@/components/Button";
 import styles from "./CreateRoom.module.scss";
 import Header from "@/components/Header";
+import zod from "zod";
+
+const createRoomSchema = zod.object({
+	voterOptions: zod.enum(["fibonacci", "linear"]),
+	numberOfOptions: zod.number().min(2).max(15),
+	noVote: zod.boolean(),
+});
+
+const createRoomWithNameSchema = createRoomSchema.extend({
+	moderatorName: zod
+		.string()
+		.min(1, { message: "Must provide a value for name." })
+		.max(10, { message: "Name too long. Must be no more than 10 characters." }),
+});
+
+function safeJSONParse<T>(value: string): T | undefined {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return undefined;
+	}
+}
 
 const options = {
 	fibonacci: [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987],
 	linear: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
 };
-
-interface CreateRoomFormValues {
-	voterOptions: "fibonacci" | "linear";
-	numberOfOptions: number;
-	noVote: boolean;
-}
 
 function getFormValues(form: HTMLFormElement) {
 	const formData = new FormData(form);
@@ -34,9 +50,16 @@ const CreateRoom: Component = () => {
 
 	const defaultName = localStorage.getItem("name") ?? "";
 	const rawSavedFormValues = localStorage.getItem("newRoomFields");
-	const defaultFormValues = (
-		rawSavedFormValues ? JSON.parse(rawSavedFormValues) : undefined
-	) as CreateRoomFormValues | undefined;
+	const parsedSavedFormValues = rawSavedFormValues
+		? safeJSONParse(rawSavedFormValues)
+		: undefined;
+
+	const createRoomSchemaCheck = createRoomSchema.safeParse(
+		parsedSavedFormValues,
+	);
+	const defaultFormValues = createRoomSchemaCheck.success
+		? createRoomSchemaCheck.data
+		: undefined;
 
 	const handleSubmit = (form: EventTarget & HTMLFormElement): void => {
 		const formData = getFormValues(form);
@@ -53,6 +76,21 @@ const CreateRoom: Component = () => {
 
 		if (formData.noVote) {
 			fieldOptions = [0, ...fieldOptions];
+		}
+
+		const createRoomWithNameSchemaCheck =
+			createRoomWithNameSchema.safeParse(formData);
+
+		if (!createRoomWithNameSchemaCheck.success) {
+			const allErrorMessages =
+				createRoomWithNameSchemaCheck.error.flatten().fieldErrors;
+
+			const singleErrorMessage = Object.entries(allErrorMessages)
+				.map(([key, value]) => `${key}: ${value.join("; ")}`)
+				.join("\n");
+
+			setError(singleErrorMessage);
+			return;
 		}
 
 		post("/api/v1/create", { options: fieldOptions })
@@ -126,8 +164,11 @@ const CreateRoom: Component = () => {
 						</label>
 						<input
 							autofocus
+							id="moderatorName"
 							name="moderatorName"
 							required
+							minLength="1"
+							maxLength="10"
 							type="text"
 							value={defaultName}
 						/>
@@ -159,6 +200,7 @@ const CreateRoom: Component = () => {
 						</label>
 						<input
 							type="range"
+							id="numberOfOptions"
 							name="numberOfOptions"
 							min="2"
 							max="15"
@@ -191,10 +233,10 @@ const CreateRoom: Component = () => {
 						</label>
 					</fieldset>
 
-					<div class={styles.finalPreview}>
+					<dl class={styles.finalPreview}>
 						<dt>Final preview</dt>
 						<dd>{list}</dd>
-					</div>
+					</dl>
 
 					<div class={styles.seperator}>
 						<hr />

--- a/web/src/pages/JoinRoom/JoinRoom.tsx
+++ b/web/src/pages/JoinRoom/JoinRoom.tsx
@@ -18,6 +18,10 @@ const JoinRoom: Component = () => {
 			setErrorMsg("Please enter a name.");
 			return;
 		}
+		if (name.length > 10) {
+			setErrorMsg("Name too long. Must be no more than 10 characters.");
+			return;
+		}
 
 		localStorage.setItem("name", name);
 		navigate(`/room/${roomCode}`);
@@ -40,6 +44,7 @@ const JoinRoom: Component = () => {
 						type="text"
 						required
 						minLength="1"
+						maxLength="10"
 						autofocus
 						value={localStorage.getItem("name") ?? ""}
 						onInput={() => setErrorMsg(null)}


### PR DESCRIPTION
Closes #64 

This work adds better end-to-end validation for the various user input methods such as:
 - Creating a room
 - Setting a name
 - Making a selection

Attempting to parse saved room data will now go through Zod validation before prefilling the form. If the validation fails no fields are prefilled. When submitting new room data the FE runs validation on all fields and the BE will run validation on the received `options` property.

When setting a name, it is now limited to a max of 10 characters. This is checked on the FE. The BE will just truncate the name to 10 characters if it's too long. If the name already exists in the room, we will automatically add `({index})` to the end of the name to reduce confusion.

When an option is selected we verify it was done by a voter in the room.