### PR TITLE
Move stale document cleanup to MongoDB with Indexes

### DIFF
--- a/server/controllers/room.controller.ts
+++ b/server/controllers/room.controller.ts
@@ -26,6 +26,7 @@ export const createRoom: OpineController = async (req, res) => {
 			options,
 			voters: [],
 			votingStartedAt: null,
+			lastUpdated: new Date(),
 		});
 		console.debug(
 			`Room created with _id of ${room} and roomCode of ${roomCode}`,

--- a/server/deps.ts
+++ b/server/deps.ts
@@ -12,6 +12,8 @@ export {
 	ObjectId,
 	Collection,
 	Database,
+	type IndexOptions,
+	type UpdateFilter,
 } from "https://deno.land/x/mongo@v0.30.1/mod.ts";
 export {
 	getCookies,

--- a/server/models/rooms.ts
+++ b/server/models/rooms.ts
@@ -1,0 +1,40 @@
+import { ObjectId, UpdateFilter } from "../deps.ts";
+import type { RoomSchema } from "../types/schemas.ts";
+import connectToDb from "../utils/db.ts";
+
+const { rooms } = await connectToDb();
+
+export const findByRoomCode = (
+	roomCode: string,
+): ReturnType<typeof rooms.findOne> => {
+	return rooms.findOne({ roomCode });
+};
+
+export const findById = (id: ObjectId): ReturnType<typeof rooms.findOne> => {
+	return rooms.findOne({ _id: id });
+};
+
+export const updateById = (
+	id: ObjectId,
+	updates: UpdateFilter<RoomSchema>,
+): ReturnType<typeof rooms.findAndModify> => {
+	return rooms.findAndModify(
+		{ _id: id },
+		{
+			update: {
+				...updates,
+				$set: {
+					...updates.$set,
+					lastUpdated: new Date(),
+				},
+			},
+			new: true,
+		},
+	);
+};
+
+export const deleteById = (
+	id: ObjectId,
+): ReturnType<typeof rooms.deleteOne> => {
+	return rooms.deleteOne({ _id: id });
+};

--- a/server/types/schemas.ts
+++ b/server/types/schemas.ts
@@ -31,10 +31,11 @@ export interface RoomSchema {
 	options: number[];
 	voters: Voter[];
 	votingStartedAt: Date | null;
+	lastUpdated: Date;
 }
 
 export interface SessionSchema {
 	_id: ObjectId;
-	maxAge: number;
+	maxAge: Date;
 	environment: "local" | "test" | "prod";
 }


### PR DESCRIPTION
Closes #68 

This work shifts the responsibility of cleaning up stale rooms and sessions to MongoDB using [TTL indexes](https://www.mongodb.com/docs/manual/core/index-ttl/).

## New Indexes
The `RoomSchema` now has a `lastUpdated` field that is updated to the current time on every update. The `"StaleRoomIndex"` will automatically remove any documents where `lastUpdated` hasn't been updated in 1 hour.

The `SessionSchema`'s `maxAge` is not a Date instead of a timestamp. The `"StaleSessionIndex"` will automatically remove a document if the current time is equal to or greater than the `maxAge`.

## Side effects
 - All room updates now need to also update `lastUpdated`. To make this easier, created a rooms model with a `updateById` wrapper function that already includes updating `lastUpdated`.
 - Session `maxAge` values are now refreshed on every request instead of a 30 second interval.