### PR TITLE
Fix not being able to switch rooms from the Room page

### DIFF
--- a/server/routes/socket.routes.ts
+++ b/server/routes/socket.routes.ts
@@ -3,12 +3,13 @@ import { handleWs } from "../controllers/socket.controller.ts";
 
 const router = Router();
 
-router.get("/", async (req, res, next) => {
+router.get("/:roomCode", async (req, res, next) => {
 	if (req.headers.get("upgrade") === "websocket") {
 		const sock = req.upgrade();
 		const sessionId = getCookies(req.headers)["session"];
+		const roomCode = req.params.roomCode;
 
-		await handleWs(sock, sessionId);
+		await handleWs(sock, sessionId, roomCode);
 	} else {
 		return res.send("You've gotta set the magic header...");
 	}

--- a/server/types/socket.ts
+++ b/server/types/socket.ts
@@ -12,7 +12,6 @@ export interface RoomUpdateEvent {
 
 export interface JoinEvent {
 	event: "Join";
-	roomCode: string;
 	name: string;
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
 		<meta name="apple-mobile-web-app-status-bar" content="#f48241" />
 		<meta name="theme-color" content="#f48241" />
 
-		<link rel="manifest" href="site.webmanifest" />
+		<link rel="manifest" href="/site.webmanifest" />
 
 		<!-- Social tags -->
 		<meta property="og:title" content="Devs Playing Poker" />

--- a/web/src/pages/Room/Room.tsx
+++ b/web/src/pages/Room/Room.tsx
@@ -80,7 +80,7 @@ interface RoomProps {
 	resetConnection: () => void;
 }
 
-const Room: Component<RoomProps> = ({ roomCode, resetConnection }) => {
+const Room: Component<RoomProps> = (props) => {
 	const navigate = useNavigate();
 	const [roomDetails, setRoomDetails] = createStore<
 		RoomDetails | EmptyRoomDetails
@@ -92,7 +92,7 @@ const Room: Component<RoomProps> = ({ roomCode, resetConnection }) => {
 
 	const userName = localStorage.getItem("name");
 	if (!userName) {
-		navigate(`/join/${roomCode}`);
+		navigate(`/join/${props.roomCode}`);
 		return;
 	}
 
@@ -100,12 +100,13 @@ const Room: Component<RoomProps> = ({ roomCode, resetConnection }) => {
 		const wsProtocol = window.location.protocol.includes("https")
 			? "wss"
 			: "ws";
-		const ws = new WebSocket(`${wsProtocol}://${window.location.host}/ws`);
+		const ws = new WebSocket(
+			`${wsProtocol}://${window.location.host}/ws/${props.roomCode}`,
+		);
 
 		ws.addEventListener("open", () => {
 			const joinEvent: JoinEvent = {
 				event: "Join",
-				roomCode: roomCode,
 				name: userName,
 			};
 			ws.send(JSON.stringify(joinEvent));
@@ -136,14 +137,12 @@ const Room: Component<RoomProps> = ({ roomCode, resetConnection }) => {
 		ws.addEventListener("close", (closeEvent) => {
 			// 1000 means closed normally
 			if (closeEvent.code !== 1000) {
-				resetConnection();
-			} else {
-				console.error(closeEvent.reason);
+				props.resetConnection();
 			}
 		});
 
 		onCleanup(() => {
-			ws.close();
+			ws.close(1000);
 		});
 	});
 


### PR DESCRIPTION
There's a bug where if you try to join another room while already in a room it won't disconnect you from the old room or connect you to the new room.

Repro steps:
 - Create and join a room
 - In a separate window, create and join a different room
 - Copy and paste the URL from the second room into the URL of the first window and hit enter
 - Notice how you never connect to the new room. You'll also notice that the old room was not properly cleaned up.

Because the reconnection logic relies on the `session` cookie (aka the sessionId, aka the userId) it has not context as to what room that session is connected to. So when you try to switch rooms it thinks you're just reconnecting to the same room which doesn't complete the connection handshake and doesn't clean up the old room.

The fix I implemented is to the make socket connections room aware. The socket map is now keyed off the userId + the room code. That way if the same user joins a different room, the socketId will be different and pass through the reconnection checks in the onClose event. To help support this I added `/:roomCode` as a param to the ws connection route since we have it in the FE and we need it to build the `socketId`.