### PR TITLE
New settings sidebar with change name and theme select + new toast style feedback

### DIFF
--- a/server/controllers/socket.controller.ts
+++ b/server/controllers/socket.controller.ts
@@ -11,6 +11,7 @@ import type {
 	KickVoterEvent,
 	WebScoketMessageEvent,
 	VotingDescriptionEvent,
+	ChangeNameEvent,
 } from "../types/socket.ts";
 import calculateConfidence from "../utils/calculateConfidence.ts";
 import { zod } from "../deps.ts";
@@ -363,6 +364,45 @@ const handleVotingDescription: EventFunction<VotingDescriptionEvent> = async (
 	sendRoomData(updatedRoomData);
 };
 
+const handleChangeName: EventFunction<ChangeNameEvent> = async (
+	roomData,
+	{ userId },
+	data,
+) => {
+	const updatedRoomData = await (() => {
+		if (roomData.moderator?.id === userId) {
+			return rooms.updateById(roomData._id, {
+				$set: {
+					moderator: {
+						...roomData.moderator,
+						name: data.value,
+					},
+				},
+			});
+		} else {
+			const updatedVoters = roomData.voters.map((voter) => {
+				if (voter.id === userId) {
+					return {
+						...voter,
+						name: data.value,
+					};
+				}
+				return voter;
+			});
+
+			return rooms.updateById(roomData._id, {
+				$set: {
+					voters: updatedVoters,
+				},
+			});
+		}
+	})();
+
+	if (!updatedRoomData) return;
+
+	sendRoomData(updatedRoomData);
+};
+
 /**
  * Middlewares
  */
@@ -391,6 +431,19 @@ const validateVoter: EventFunction<WebScoketMessageEvent> = (
 	}
 };
 
+const validateInRoom: EventFunction<WebScoketMessageEvent> = (...params) => {
+	const isModerator = !validateModerator(...params);
+	if (isModerator) return;
+
+	const isVoter = !validateVoter(...params);
+	if (isVoter) return;
+
+	return {
+		message:
+			"This command can only be executed by someone in the specified room which you are not.",
+	};
+};
+
 const eventHandlerMap = new Map<
 	WebScoketMessageEvent["event"],
 	Array<EventFunction<any>>
@@ -402,6 +455,7 @@ const eventHandlerMap = new Map<
 	["ModeratorChange", [validateModerator, handleModeratorChange]],
 	["KickVoter", [validateModerator, handleKickVoter]],
 	["UpdateVotingDescription", [validateModerator, handleVotingDescription]],
+	["ChangeName", [validateInRoom, handleChangeName]],
 ]);
 
 export const handleWs = (

--- a/server/controllers/socket.controller.ts
+++ b/server/controllers/socket.controller.ts
@@ -473,10 +473,13 @@ export const handleWs = (
 
 	sockets.set(socketId, socket);
 
-	socket.addEventListener("open", () => {
+	socket.addEventListener("open", async () => {
+		const roomExists = await rooms.findByRoomCode(roomCode);
+
 		const connectEvent: ConnectEvent = {
 			event: "Connected",
 			userId,
+			roomExists: !!roomExists,
 		};
 		socket.send(JSON.stringify(connectEvent));
 	});

--- a/server/types/socket.ts
+++ b/server/types/socket.ts
@@ -3,6 +3,7 @@ import type { RoomSchema } from "./schemas.ts";
 export interface ConnectEvent {
 	event: "Connected";
 	userId: string;
+	roomExists: boolean;
 }
 
 export interface RoomUpdateEvent {

--- a/server/types/socket.ts
+++ b/server/types/socket.ts
@@ -50,6 +50,11 @@ export interface VotingDescriptionEvent {
 	value: string;
 }
 
+export interface ChangeNameEvent {
+	event: "ChangeName";
+	value: string;
+}
+
 /**
  * Events triggered from the server
  */
@@ -68,6 +73,7 @@ export type WebScoketMessageEvent =
 	| StartVotingEvent
 	| StopVotingEvent
 	| KickVoterEvent
-	| VotingDescriptionEvent;
+	| VotingDescriptionEvent
+	| ChangeNameEvent;
 
 export type WebSocketEvent = WebSocketTriggeredEvent | WebScoketMessageEvent;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
 				"@zag-js/solid": "^0.2.4",
 				"solid-app-router": "^0.4.2",
 				"solid-js": "^1.6.8",
+				"solid-toast": "^0.4.0",
 				"zod": "^3.20.2"
 			},
 			"devDependencies": {
@@ -1849,6 +1850,14 @@
 				"solid-js": "^1.3"
 			}
 		},
+		"node_modules/solid-toast": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/solid-toast/-/solid-toast-0.4.0.tgz",
+			"integrity": "sha512-ciJbj+n+7KbUN6wfwZsW7lqFESLoQ9sXMG4uJWuHrIw2f0GxX3/wLSKs0Q1YwdTZZRxyRJ1Nwc2eBVcJvs91+g==",
+			"peerDependencies": {
+				"solid-js": "^1.5.4"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -3306,6 +3315,12 @@
 				"@babel/helper-module-imports": "^7.16.7",
 				"@babel/types": "^7.18.4"
 			}
+		},
+		"solid-toast": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/solid-toast/-/solid-toast-0.4.0.tgz",
+			"integrity": "sha512-ciJbj+n+7KbUN6wfwZsW7lqFESLoQ9sXMG4uJWuHrIw2f0GxX3/wLSKs0Q1YwdTZZRxyRJ1Nwc2eBVcJvs91+g==",
+			"requires": {}
 		},
 		"source-map-js": {
 			"version": "1.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
 		"@zag-js/solid": "^0.2.4",
 		"solid-app-router": "^0.4.2",
 		"solid-js": "^1.6.8",
+		"solid-toast": "^0.4.0",
 		"zod": "^3.20.2"
 	}
 }

--- a/web/src/components/Header/Header.module.scss
+++ b/web/src/components/Header/Header.module.scss
@@ -21,20 +21,14 @@
 		}
 	}
 
-	& > .themeBtn {
-		display: block;
-		width: fit-content;
+	.settingsDrawerTrigger {
+		justify-self: flex-end;
+		width: 2.5rem;
+		height: 2.5rem;
+		padding: 0;
+		color: inherit;
 
-		cursor: pointer;
-
-		margin-left: auto;
-		padding: 0.25rem 0.5rem;
-
-		border-radius: 5px;
-		border: 1px solid var(--border-gray);
-
-		background-color: var(--elevated-background);
-		color: var(--primary-text-color);
-		font-size: small;
+		display: grid;
+		place-items: center;
 	}
 }

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -1,42 +1,66 @@
 import { useIntl } from "@/i18n";
 import mergeClassNames from "@/utils/mergeClassNames";
 import { Link, useLocation } from "solid-app-router";
-import { ParentComponent, Show } from "solid-js";
+import { createSignal, ParentComponent, Show, splitProps } from "solid-js";
+import Button from "../Button";
+import SettingsDrawer, { SettingsDrawerActions } from "../SettingsDrawer";
 import styles from "./Header.module.scss";
 
-interface HeaderProps {
+interface HeaderProps extends SettingsDrawerActions {
 	class?: string;
 }
 
 const Header: ParentComponent<HeaderProps> = (props) => {
 	const intl = useIntl();
 	const location = useLocation();
+	const [drawerOpen, setDrawerOpen] = createSignal<boolean>(false);
+	const [componentProps, actions] = splitProps(props, ["class", "children"]);
 
 	return (
-		<header class={mergeClassNames(styles.header, props.class)}>
-			<div class={styles.homeLinkContainer}>
-				<Show when={location.pathname !== "/"}>
-					<Link href="/">
-						<span aria-hidden>🏠</span>
-						{intl.t("home")}
-					</Link>
-				</Show>
-			</div>
-			{props.children}
-			<button
-				class={styles.themeBtn}
-				type="button"
-				onClick={() => {
-					document.body.classList.toggle("dark");
-					localStorage.setItem(
-						"theme",
-						document.body.classList.contains("dark") ? "dark" : "light",
-					);
-				}}
-			>
-				{intl.t("toggleTheme")}
-			</button>
-		</header>
+		<>
+			<header class={mergeClassNames(styles.header, componentProps.class)}>
+				<div class={styles.homeLinkContainer}>
+					<Show when={location.pathname !== "/"}>
+						<Link href="/">
+							<span aria-hidden>🏠</span>
+							{intl.t("home")}
+						</Link>
+					</Show>
+				</div>
+				{componentProps.children}
+				<Button
+					onClick={[setDrawerOpen, true]}
+					variant="ghost"
+					class={styles.settingsDrawerTrigger}
+					title={intl.t("openSettingsDrawer") as string}
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke-width="1.5"
+						stroke="currentColor"
+						width="24"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
+						/>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+						/>
+					</svg>
+				</Button>
+			</header>
+			<SettingsDrawer
+				isOpen={drawerOpen()}
+				onClose={() => setDrawerOpen(false)}
+				{...actions}
+			/>
+		</>
 	);
 };
 

--- a/web/src/components/SettingsDrawer/SettingsDrawer.module.scss
+++ b/web/src/components/SettingsDrawer/SettingsDrawer.module.scss
@@ -58,6 +58,7 @@
 		padding: 0.5rem 0.75rem;
 		width: 100%;
 		margin: 0.5rem 0px 0.5rem 0px;
+		border: 2px solid var(--border-gray);
 	}
 
 	p {
@@ -72,6 +73,28 @@
 	}
 }
 
-button.themeBtn {
-	padding: 0.5rem;
+.themeSelect {
+	label {
+		display: block;
+		font-weight: 600;
+	}
+
+	select,
+	option {
+		border-radius: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		width: 100%;
+		margin: 0.5rem 0px 0.5rem 0px;
+		border: 2px solid var(--border-gray);
+		color: inherit;
+	}
+
+	option {
+		background-color: var(--elevated-background);
+		color: var(--primary-text-color);
+	}
+
+	p {
+		color: var(--secondary-text-color);
+	}
 }

--- a/web/src/components/SettingsDrawer/SettingsDrawer.module.scss
+++ b/web/src/components/SettingsDrawer/SettingsDrawer.module.scss
@@ -1,44 +1,49 @@
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes slideIn {
+	from {
+		transform: translateX(100%);
+	}
+	to {
+		transform: translateX(0);
+	}
+}
+
 .backdrop {
 	position: absolute;
 	background-color: rgba(0, 0, 0, 0.25);
 	overflow: hidden;
-	right: 0;
+	inset: 0;
+	animation: fadeIn 200ms cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.drawer {
+	width: 20rem;
+	padding: 1rem;
+	position: absolute;
 	top: 0;
-	width: 0;
 	height: 100vh;
-	z-index: 999;
+	right: 0;
+	background-color: var(--elevated-background);
 
-	.drawer {
-		width: 20rem;
-		padding: 1rem;
-		position: absolute;
-		top: 0;
-		height: 100vh;
-		right: 0;
-		background-color: var(--elevated-background);
-		transform: translateX(100%);
+	display: flex;
+	flex-direction: column;
+	gap: 2rem;
+	animation: slideIn 200ms cubic-bezier(0.165, 0.84, 0.44, 1);
 
-		display: flex;
-		flex-direction: column;
-		gap: 2rem;
-
-		transition: transform 200ms cubic-bezier(0.165, 0.84, 0.44, 1);
-
-		.closeBtn {
-			color: var(--primary-text-color);
-			width: 2.5rem;
-			height: 2.5rem;
-			padding: 0;
-			margin-left: auto;
-		}
-	}
-
-	&.open {
-		width: 100vw;
-
-		.drawer {
-			transform: translateX(0);
-		}
+	.closeBtn {
+		color: var(--primary-text-color);
+		width: 2.5rem;
+		height: 2.5rem;
+		padding: 0;
+		margin-left: auto;
 	}
 }
 
@@ -59,6 +64,7 @@
 		width: 100%;
 		margin: 0.5rem 0px 0.5rem 0px;
 		border: 2px solid var(--border-gray);
+		background-color: var(--main-background);
 	}
 
 	p {
@@ -87,6 +93,7 @@
 		margin: 0.5rem 0px 0.5rem 0px;
 		border: 2px solid var(--border-gray);
 		color: inherit;
+		background-color: var(--main-background);
 	}
 
 	option {

--- a/web/src/components/SettingsDrawer/SettingsDrawer.module.scss
+++ b/web/src/components/SettingsDrawer/SettingsDrawer.module.scss
@@ -1,0 +1,77 @@
+.backdrop {
+	position: absolute;
+	background-color: rgba(0, 0, 0, 0.25);
+	overflow: hidden;
+	right: 0;
+	top: 0;
+	width: 0;
+	height: 100vh;
+	z-index: 999;
+
+	.drawer {
+		width: 20rem;
+		padding: 1rem;
+		position: absolute;
+		top: 0;
+		height: 100vh;
+		right: 0;
+		background-color: var(--elevated-background);
+		transform: translateX(100%);
+
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+
+		transition: transform 200ms cubic-bezier(0.165, 0.84, 0.44, 1);
+
+		.closeBtn {
+			color: var(--primary-text-color);
+			width: 2.5rem;
+			height: 2.5rem;
+			padding: 0;
+			margin-left: auto;
+		}
+	}
+
+	&.open {
+		width: 100vw;
+
+		.drawer {
+			transform: translateX(0);
+		}
+	}
+}
+
+.nameForm {
+	label {
+		display: block;
+		font-weight: 600;
+
+		&::after {
+			content: " *";
+			color: var(--error-text-color);
+		}
+	}
+
+	input {
+		border-radius: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		width: 100%;
+		margin: 0.5rem 0px 0.5rem 0px;
+	}
+
+	p {
+		color: var(--error-text-color);
+		margin: 0px;
+	}
+
+	button {
+		display: block;
+		width: 100%;
+		padding: 0.5rem;
+	}
+}
+
+button.themeBtn {
+	padding: 0.5rem;
+}

--- a/web/src/components/SettingsDrawer/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer/SettingsDrawer.tsx
@@ -1,6 +1,7 @@
 import { IntlKey, useIntl } from "@/i18n";
 import {
 	createSignal,
+	JSX,
 	onCleanup,
 	onMount,
 	ParentComponent,
@@ -32,6 +33,28 @@ const SettingsDrawer: ParentComponent<SettingsDrawerProps> = (props) => {
 		onCleanup(() => document.removeEventListener("keyup", escClose));
 	});
 
+	const handleThemeChange: JSX.EventHandlerUnion<HTMLSelectElement, Event> = (
+		e,
+	) => {
+		const selection = e.currentTarget.value;
+
+		if (selection === "system") {
+			localStorage.setItem("theme", "system");
+
+			if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+				document.body.classList.add("dark");
+			} else {
+				document.body.classList.remove("dark");
+			}
+		} else if (selection === "light") {
+			localStorage.setItem("theme", "light");
+			document.body.classList.remove("dark");
+		} else if (selection === "dark") {
+			localStorage.setItem("theme", "dark");
+			document.body.classList.add("dark");
+		}
+	};
+
 	return (
 		<div
 			class={styles.backdrop}
@@ -47,20 +70,21 @@ const SettingsDrawer: ParentComponent<SettingsDrawerProps> = (props) => {
 				>
 					&#10005;
 				</Button>
-				<Button
-					variant="outline"
-					class={styles.themeBtn}
-					type="button"
-					onClick={() => {
-						document.body.classList.toggle("dark");
-						localStorage.setItem(
-							"theme",
-							document.body.classList.contains("dark") ? "dark" : "light",
-						);
-					}}
-				>
-					{intl.t("toggleTheme")}
-				</Button>
+				<div class={styles.themeSelect}>
+					<label for="theme-select">Theme</label>
+					<select
+						id="theme-select"
+						name="theme-select"
+						aria-describedby="theme-select-helptext"
+						value={localStorage.getItem("theme") ?? "system"}
+						onChange={handleThemeChange}
+					>
+						<option value="system">System Setting</option>
+						<option value="light">Light</option>
+						<option value="dark">Dark</option>
+					</select>
+					<p id="theme-select-helptext">Saves automatically.</p>
+				</div>
 				<Show when={props.onSaveName}>
 					<form
 						class={styles.nameForm}

--- a/web/src/components/SettingsDrawer/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer/SettingsDrawer.tsx
@@ -71,7 +71,7 @@ const SettingsDrawer: ParentComponent<SettingsDrawerProps> = (props) => {
 					&#10005;
 				</Button>
 				<div class={styles.themeSelect}>
-					<label for="theme-select">Theme</label>
+					<label for="theme-select">{intl.t("theme")}</label>
 					<select
 						id="theme-select"
 						name="theme-select"
@@ -79,11 +79,11 @@ const SettingsDrawer: ParentComponent<SettingsDrawerProps> = (props) => {
 						value={localStorage.getItem("theme") ?? "system"}
 						onChange={handleThemeChange}
 					>
-						<option value="system">System Setting</option>
-						<option value="light">Light</option>
-						<option value="dark">Dark</option>
+						<option value="system">{intl.t("system")}</option>
+						<option value="light">{intl.t("light")}</option>
+						<option value="dark">{intl.t("dark")}</option>
 					</select>
-					<p id="theme-select-helptext">Saves automatically.</p>
+					<p id="theme-select-helptext">{intl.t("savesAutomatically")}</p>
 				</div>
 				<Show when={props.onSaveName}>
 					<form

--- a/web/src/components/SettingsDrawer/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer/SettingsDrawer.tsx
@@ -1,0 +1,109 @@
+import { IntlKey, useIntl } from "@/i18n";
+import {
+	createSignal,
+	onCleanup,
+	onMount,
+	ParentComponent,
+	Show,
+} from "solid-js";
+import Button from "../Button";
+import styles from "./SettingsDrawer.module.scss";
+
+export interface SettingsDrawerActions {
+	onSaveName?: (name: string) => void;
+}
+
+type SettingsDrawerProps = {
+	isOpen: boolean;
+	onClose: () => void;
+} & SettingsDrawerActions;
+
+const SettingsDrawer: ParentComponent<SettingsDrawerProps> = (props) => {
+	const intl = useIntl();
+	const [errorMsg, setErrorMsg] = createSignal<IntlKey | null>(null);
+
+	onMount(() => {
+		const escClose = (e: KeyboardEvent) => {
+			if (e.key === "Escape" && props.isOpen) {
+				props.onClose();
+			}
+		};
+		document.addEventListener("keyup", escClose);
+		onCleanup(() => document.removeEventListener("keyup", escClose));
+	});
+
+	return (
+		<div
+			class={styles.backdrop}
+			classList={{ [styles.open]: props.isOpen }}
+			onClick={props.onClose}
+		>
+			<aside class={styles.drawer} onClick={(e) => e.stopPropagation()}>
+				<Button
+					variant="ghost"
+					onClick={props.onClose}
+					class={styles.closeBtn}
+					title={intl.t("closeSettingsDrawer") as string}
+				>
+					&#10005;
+				</Button>
+				<Button
+					variant="outline"
+					class={styles.themeBtn}
+					type="button"
+					onClick={() => {
+						document.body.classList.toggle("dark");
+						localStorage.setItem(
+							"theme",
+							document.body.classList.contains("dark") ? "dark" : "light",
+						);
+					}}
+				>
+					{intl.t("toggleTheme")}
+				</Button>
+				<Show when={props.onSaveName}>
+					<form
+						class={styles.nameForm}
+						onSubmit={(e) => {
+							e.preventDefault();
+							const formData = new FormData(e.currentTarget);
+							const name = formData.get("name")?.toString().trim();
+
+							if (!name || name.length === 0) {
+								setErrorMsg("enterAName");
+								return;
+							}
+							if (name.length > 10) {
+								setErrorMsg("nameTooLong");
+								return;
+							}
+
+							props.onSaveName!(name);
+						}}
+					>
+						<label for="name">{intl.t("name")}</label>
+						<input
+							id="name"
+							name="name"
+							type="text"
+							required
+							minLength="1"
+							maxLength="10"
+							autofocus
+							value={localStorage.getItem("name") ?? ""}
+							onInput={() => setErrorMsg(null)}
+							aria-describedby="name-error-msg"
+							aria-invalid={Boolean(errorMsg())}
+						/>
+						<Show when={errorMsg()} keyed>
+							{(msg) => <p id="name-error-msg">{intl.t(msg)}</p>}
+						</Show>
+						<Button type="submit">{intl.t("saveName")}</Button>
+					</form>
+				</Show>
+			</aside>
+		</div>
+	);
+};
+
+export default SettingsDrawer;

--- a/web/src/components/SettingsDrawer/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer/SettingsDrawer.tsx
@@ -7,6 +7,7 @@ import {
 	ParentComponent,
 	Show,
 } from "solid-js";
+import { Portal } from "solid-js/web";
 import Button from "../Button";
 import styles from "./SettingsDrawer.module.scss";
 
@@ -56,77 +57,77 @@ const SettingsDrawer: ParentComponent<SettingsDrawerProps> = (props) => {
 	};
 
 	return (
-		<div
-			class={styles.backdrop}
-			classList={{ [styles.open]: props.isOpen }}
-			onClick={props.onClose}
-		>
-			<aside class={styles.drawer} onClick={(e) => e.stopPropagation()}>
-				<Button
-					variant="ghost"
-					onClick={props.onClose}
-					class={styles.closeBtn}
-					title={intl.t("closeSettingsDrawer") as string}
-				>
-					&#10005;
-				</Button>
-				<div class={styles.themeSelect}>
-					<label for="theme-select">{intl.t("theme")}</label>
-					<select
-						id="theme-select"
-						name="theme-select"
-						aria-describedby="theme-select-helptext"
-						value={localStorage.getItem("theme") ?? "system"}
-						onChange={handleThemeChange}
-					>
-						<option value="system">{intl.t("system")}</option>
-						<option value="light">{intl.t("light")}</option>
-						<option value="dark">{intl.t("dark")}</option>
-					</select>
-					<p id="theme-select-helptext">{intl.t("savesAutomatically")}</p>
-				</div>
-				<Show when={props.onSaveName}>
-					<form
-						class={styles.nameForm}
-						onSubmit={(e) => {
-							e.preventDefault();
-							const formData = new FormData(e.currentTarget);
-							const name = formData.get("name")?.toString().trim();
+		<Portal>
+			<Show when={props.isOpen}>
+				<div class={styles.backdrop} onClick={props.onClose}>
+					<aside class={styles.drawer} onClick={(e) => e.stopPropagation()}>
+						<Button
+							variant="ghost"
+							onClick={props.onClose}
+							class={styles.closeBtn}
+							title={intl.t("closeSettingsDrawer") as string}
+						>
+							&#10005;
+						</Button>
+						<div class={styles.themeSelect}>
+							<label for="theme-select">{intl.t("theme")}</label>
+							<select
+								id="theme-select"
+								name="theme-select"
+								aria-describedby="theme-select-helptext"
+								value={localStorage.getItem("theme") ?? "system"}
+								onChange={handleThemeChange}
+							>
+								<option value="system">{intl.t("system")}</option>
+								<option value="light">{intl.t("light")}</option>
+								<option value="dark">{intl.t("dark")}</option>
+							</select>
+							<p id="theme-select-helptext">{intl.t("savesAutomatically")}</p>
+						</div>
+						<Show when={props.onSaveName}>
+							<form
+								class={styles.nameForm}
+								onSubmit={(e) => {
+									e.preventDefault();
+									const formData = new FormData(e.currentTarget);
+									const name = formData.get("name")?.toString().trim();
 
-							if (!name || name.length === 0) {
-								setErrorMsg("enterAName");
-								return;
-							}
-							if (name.length > 10) {
-								setErrorMsg("nameTooLong");
-								return;
-							}
+									if (!name || name.length === 0) {
+										setErrorMsg("enterAName");
+										return;
+									}
+									if (name.length > 10) {
+										setErrorMsg("nameTooLong");
+										return;
+									}
 
-							props.onSaveName!(name);
-						}}
-					>
-						<label for="name">{intl.t("name")}</label>
-						<input
-							id="name"
-							name="name"
-							type="text"
-							required
-							minLength="1"
-							maxLength="10"
-							autofocus
-							value={localStorage.getItem("name") ?? ""}
-							onInput={() => setErrorMsg(null)}
-							aria-describedby="name-error-msg"
-							aria-invalid={Boolean(errorMsg())}
-						/>
-						<Show when={errorMsg()} keyed>
-							{(msg) => <p id="name-error-msg">{intl.t(msg)}</p>}
+									props.onSaveName!(name);
+								}}
+							>
+								<label for="name">{intl.t("name")}</label>
+								<input
+									id="name"
+									name="name"
+									type="text"
+									required
+									minLength="1"
+									maxLength="10"
+									autofocus
+									value={localStorage.getItem("name") ?? ""}
+									onInput={() => setErrorMsg(null)}
+									aria-describedby="name-error-msg"
+									aria-invalid={Boolean(errorMsg())}
+								/>
+								<Show when={errorMsg()} keyed>
+									{(msg) => <p id="name-error-msg">{intl.t(msg)}</p>}
+								</Show>
+								<Button type="submit">{intl.t("saveName")}</Button>
+							</form>
 						</Show>
-						<Button type="submit">{intl.t("saveName")}</Button>
-					</form>
-				</Show>
-			</aside>
-		</div>
+					</aside>
+				</div>
+			</Show>
+		</Portal>
 	);
 };
 

--- a/web/src/components/SettingsDrawer/index.ts
+++ b/web/src/components/SettingsDrawer/index.ts
@@ -1,0 +1,1 @@
+export { default, type SettingsDrawerActions } from "./SettingsDrawer";

--- a/web/src/i18n/translations/en.json
+++ b/web/src/i18n/translations/en.json
@@ -9,7 +9,6 @@
 
 	"_HEADER_": "",
 	"home": "Home",
-	"toggleTheme": "Toggle Theme",
 
 	"_JOIN_ROOM_": "",
 	"name": "Name",
@@ -85,5 +84,10 @@
 	"_SETTINGS_DRAWER_": "",
 	"openSettingsDrawer": "Open settings drawer.",
 	"closeSettingsDrawer": "Close settings drawer.",
-	"saveName": "Save Name"
+	"saveName": "Save Name",
+	"theme": "Theme",
+	"system": "System Setting",
+	"light": "Light",
+	"dark": "Dark",
+	"savesAutomatically": "Saves automatically."
 }

--- a/web/src/i18n/translations/en.json
+++ b/web/src/i18n/translations/en.json
@@ -34,6 +34,9 @@
 	"connecting": "Connecting...",
 	"checkingRoom": "Checking room...",
 	"copyCode": "Click to copy code.",
+	"thatRoomDoesntExist": "Room with code <b>{roomCode}</b> does not exist.",
+	"youWereKicked": "You were kicked.",
+	"nameUpdated": "Name updated.",
 
 	"_ROOM_VOTER_VIEW_": "",
 	"waitingForModerator": "Waiting for {moderatorName}...",

--- a/web/src/i18n/translations/en.json
+++ b/web/src/i18n/translations/en.json
@@ -77,5 +77,10 @@
 	"whatWereVotingOn": "What we're voting on",
 	"edit": "Edit",
 	"clear": "Clear",
-	"addVotingDesc": "Add voting description"
+	"addVotingDesc": "Add voting description",
+
+	"_SETTINGS_DRAWER_": "",
+	"openSettingsDrawer": "Open settings drawer.",
+	"closeSettingsDrawer": "Close settings drawer.",
+	"saveName": "Save Name"
 }

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -72,6 +72,17 @@ hr {
 	overflow: visible;
 }
 
+// solid-toast uses inline styles 🙄
+.toast {
+	background-color: var(--elevated-background) !important;
+	color: var(--primary-text-color) !important;
+
+	& [role="status"] {
+		// the default is flex which removes spaces for formatted elements
+		display: block !important;
+	}
+}
+
 @keyframes flipIn {
 	from {
 		scale: 0.9;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -2,6 +2,7 @@
 import { render } from "solid-js/web";
 import type { Component } from "solid-js";
 import { Router } from "solid-app-router";
+import { Toaster } from "solid-toast";
 import IntlProvider from "./i18n";
 import App from "./App";
 
@@ -13,6 +14,7 @@ const Index: Component = () => {
 		<IntlProvider locale="en">
 			<Router>
 				<App />
+				<Toaster position="top-center" toastOptions={{ className: "toast" }} />
 			</Router>
 		</IntlProvider>
 	);

--- a/web/src/interpretTheme.ts
+++ b/web/src/interpretTheme.ts
@@ -1,14 +1,14 @@
 window.onload = () => {
-	const savedPreference = localStorage.getItem("theme");
+	const savedPreference = localStorage.getItem("theme") ?? "system";
 
-	if (savedPreference && savedPreference === "dark") {
+	if (savedPreference === "dark") {
 		document.body.classList.add("dark");
-	} else if (
-		!savedPreference &&
-		window.matchMedia("(prefers-color-scheme: dark)").matches
-	) {
+	} else if (savedPreference === "light") {
+		document.body.classList.remove("dark");
+	} else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
 		document.body.classList.add("dark");
-		localStorage.setItem("theme", "dark");
+	} else {
+		document.body.classList.remove("dark");
 	}
 };
 export {};

--- a/web/src/pages/Landing/Landing.tsx
+++ b/web/src/pages/Landing/Landing.tsx
@@ -66,7 +66,9 @@ const Landing: Component = () => {
 
 	return (
 		<>
-			<Header />
+			<Header
+				onSaveName={(new_name) => localStorage.setItem("name", new_name)}
+			/>
 			<main class={styles.landing}>
 				<section class={styles.copy}>
 					<h1>🃏 Devs Playing Poker</h1>

--- a/web/src/pages/Room/Room.tsx
+++ b/web/src/pages/Room/Room.tsx
@@ -20,6 +20,7 @@ import {
 } from "./RoomContext";
 import { useIntl } from "@/i18n";
 import VotingDescription from "./components/VotingDescription";
+import toast from "solid-toast";
 
 const [updateNameFn, setUpdateNameFn] = createSignal<
 	((name: string) => void) | undefined
@@ -41,6 +42,9 @@ const RoomCheckWrapper: Component = () => {
 	const [roomExists] = createResource(params.roomCode, () =>
 		fetch(`/api/v1/rooms/${params.roomCode}/checkRoomExists`).then((res) => {
 			if (res.status !== 200) {
+				toast.error(
+					intl.t("thatRoomDoesntExist", { roomCode: params.roomCode }),
+				);
 				navigate("/");
 				return false;
 			}
@@ -86,7 +90,9 @@ const wsProtocol = window.location.protocol.includes("https") ? "wss" : "ws";
 const wsPath = `${wsProtocol}://${window.location.host}/ws`;
 
 const Room: Component<RoomProps> = (props) => {
+	const intl = useIntl();
 	const navigate = useNavigate();
+
 	const wsUrl = () => {
 		const wsUrl = new URL(`${wsPath}/${props.roomCode}`);
 		if (props.userId) {
@@ -154,6 +160,7 @@ const Room: Component<RoomProps> = (props) => {
 					break;
 				}
 				case "Kicked":
+					toast(intl.t("youWereKicked"), { icon: "🥾" });
 					navigate("/");
 					break;
 				default:
@@ -180,6 +187,8 @@ const Room: Component<RoomProps> = (props) => {
 			event: "ChangeName",
 			value: new_name,
 		});
+		localStorage.setItem("name", new_name);
+		toast.success(intl.t("nameUpdated"));
 	});
 
 	return (

--- a/web/src/pages/Room/Room.tsx
+++ b/web/src/pages/Room/Room.tsx
@@ -21,6 +21,10 @@ import {
 import { useIntl } from "@/i18n";
 import VotingDescription from "./components/VotingDescription";
 
+const [updateNameFn, setUpdateNameFn] = createSignal<
+	((name: string) => void) | undefined
+>();
+
 const RoomCheckWrapper: Component = () => {
 	const intl = useIntl();
 	const navigate = useNavigate();
@@ -46,7 +50,7 @@ const RoomCheckWrapper: Component = () => {
 
 	return (
 		<>
-			<Header>
+			<Header onSaveName={updateNameFn()}>
 				<button
 					class={styles.roomCodeBtn}
 					onClick={() => navigator.clipboard.writeText(params.roomCode)}
@@ -169,6 +173,13 @@ const Room: Component<RoomProps> = (props) => {
 		if (ws().readyState === WebSocket.OPEN) {
 			ws().close(1000);
 		}
+	});
+
+	setUpdateNameFn(() => (new_name) => {
+		roomDetails.dispatchEvent({
+			event: "ChangeName",
+			value: new_name,
+		});
 	});
 
 	return (

--- a/web/src/pages/Room/Room.tsx
+++ b/web/src/pages/Room/Room.tsx
@@ -30,7 +30,6 @@ const Room: Component = () => {
 	const params = useParams();
 
 	const userName = localStorage.getItem("name");
-	const userId = sessionStorage.getItem("userId");
 
 	return (
 		<>
@@ -49,11 +48,7 @@ const Room: Component = () => {
 				keyed
 			>
 				{(userName) => (
-					<RoomContent
-						roomCode={params.roomCode}
-						userName={userName}
-						userId={userId}
-					/>
+					<RoomContent roomCode={params.roomCode} userName={userName} />
 				)}
 			</Show>
 		</>
@@ -63,7 +58,6 @@ const Room: Component = () => {
 interface RoomContentProps {
 	roomCode: string;
 	userName: string;
-	userId: string | null;
 }
 
 const wsProtocol = window.location.protocol.includes("https") ? "wss" : "ws";
@@ -72,11 +66,12 @@ const wsPath = `${wsProtocol}://${window.location.host}/ws`;
 const RoomContent: Component<RoomContentProps> = (props) => {
 	const intl = useIntl();
 	const navigate = useNavigate();
+	const savedUserId = sessionStorage.getItem("userId");
 
 	const wsUrl = () => {
 		const wsUrl = new URL(`${wsPath}/${props.roomCode}`);
-		if (props.userId) {
-			wsUrl.searchParams.set("userId", props.userId);
+		if (savedUserId) {
+			wsUrl.searchParams.set("userId", savedUserId);
 		}
 		return wsUrl;
 	};
@@ -140,7 +135,7 @@ const RoomContent: Component<RoomContentProps> = (props) => {
 						return navigate("/");
 					}
 
-					if (data.userId !== props.userId) {
+					if (data.userId !== savedUserId) {
 						sessionStorage.setItem("userId", data.userId);
 					}
 					setRoomDetails({ currentUserId: data.userId });


### PR DESCRIPTION
Closes #62 

This work adds a new sidebar for common settings such as theme switching and changing your name. You can now change your name on the Home and Room screens. The theme switcher is now a select between system, light, and dark.

Also, there are some places where we were redirecting the user in code without any explanation. This work adds solid-toast so that we can display toasts with those explanations!

Also, slight change to how a room is verified on join. The check is now done during the WS Connect event. If the room does not exist we interrupt the handshake and navigate you away with a toast.

BE Changes:
 - Added `ChangeNameEvent` to handle when a user changes their name inside of a room.
 - Added `roomExists` to `Connect` event.

FE Changes:
 - Moved theme toggle into new SettingsDrawer
 - Made theme toggle a theme select
 - Added SettingsDrawer for theme switching and name changing. This is rendered as part of the Header since that's where the trigger lives on every page.
 - Added toaster and styles to main index files
 - Adjusted interpretTheme to handle system setting. Closely aligns with implementation in SettingsSidebar.
 - Added name change handling to Landing and Room
 - In Room, move room check handling to the Connect event handler and added toasts for auto-navigation events.